### PR TITLE
Fix QAFactEvalEvaluator models download (now using python libraries)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ dependencies = [
   "gdown",  
   "edlib",
   "spacy",
-  "accelerate"
+  "accelerate",
+  "gdown",
+  "wget"
 ]
 description = "Auditing Generative AI Lanugage Modeling for Trustworthiness"
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ edlib
 huggingface-hub>=0.14.0
 spacy
 accelerate
+gdown
+wget


### PR DESCRIPTION
Trying to test the tool, it came up that the download and extraction of the models to evaluate the factual consistency was executed through some terminal commands (e.g. `wget`, `tar`), run using `os.system`. The problem is that some people (like me) don't have `wget` or `tar` preinstalled.

### Solution
In order to make this code general and usable by everyone, I replaced those `os.system` with a series of functions from some well-known Python libraries: `gdown` (to download the model from Google Drive), `wget` (to download the other model from the URL), and `shutil` (to extract the downloaded files).

The `requirements.txt` and `pyproject.toml` have been updated too.